### PR TITLE
Working global projection feature with events ordering

### DIFF
--- a/src/context/context.coffee
+++ b/src/context/context.coffee
@@ -11,6 +11,7 @@ class Context
 
   constructor: (@name, @_eventric) ->
     @_initialized = false
+    @_projectionInitializable = false
     @_params = @_eventric.get()
     @_di = {}
     @_aggregateRootClasses = {}
@@ -603,6 +604,7 @@ class Context
 
   _initializeProjections: ->
     new Promise (resolve, reject) =>
+      @_projectionInitializable = true
       projections = []
       for projectionName, ProjectionClass of @_projectionClasses
         projections.push

--- a/src/projection/projection.coffee
+++ b/src/projection/projection.coffee
@@ -188,7 +188,7 @@ class Projection
         
       subProjectionName = "_globalProjection_#{projectionId}"
       subContext.addProjection subProjectionName, subProjection
-      if subContext._initialized or remote then subContext.initializeProjectionInstance subProjectionName
+      if subContext._projectionInitializable then subContext.initializeProjectionInstance subProjectionName
       
       projection.$subProjections ?= {}
       projection.$subProjections[contextName] = subProjection

--- a/src/projection/projection.coffee
+++ b/src/projection/projection.coffee
@@ -152,7 +152,12 @@ class Projection
             resolve: resolve
             reject: reject
 
-      
+  _subContextDomainEventHandler: (projection) ->
+    return (dE, p) =>
+      @_applyDomainEventToProjection dE, projection
+      .then resolve
+      .catch reject
+  
   _createSubProjection: (projectionId, projection, contextName, eventNames) ->
     new Promise (resolve, reject) =>
       remote = false
@@ -171,7 +176,7 @@ class Projection
       }
       
       for eventName in eventNames
-        subProjection["handle#{eventName}"] = projection["from#{contextName}_handle#{eventName}"].bind(projection)
+        subProjection["handle#{eventName}"] = @_subContextDomainEventHandler(projection)
         
       subProjectionName = "_globalProjection_#{projectionId}"
       subContext.addProjection subProjectionName, subProjection

--- a/src/projection/projection.coffee
+++ b/src/projection/projection.coffee
@@ -204,7 +204,7 @@ class Projection
             domainEvents = domainEvents.concat value
         
         resolvePromise = =>
-          value.promise.resolve(eventsMap) for key, value of initials when typeof value.promise isnt 'undefined'
+          value.promise.resolve() for key, value of initials when typeof value.promise isnt 'undefined'
           resolve eventsMap[@_context.name]
           
         rejectPromise = (err) =>

--- a/src/projection/projection.coffee
+++ b/src/projection/projection.coffee
@@ -13,7 +13,6 @@ class Projection
     @_projectionInstances = {}
     @_domainEventsApplied = {}
 
-
   ###*
   * @name initializeInstance
   * @module Projection
@@ -53,9 +52,9 @@ class Projection
         @_callInitializeOnProjection projectionName, projection, params
       .then =>
         @log.debug "[#{@_context.name}] Replaying DomainEvents against Projection #{projectionName}"
-        @_parseEventNamesFromProjection projection
-      .then (eventNames) =>
-        @_applyDomainEventsFromStoreToProjection projectionId, projection, eventNames, aggregateId
+        @_parseEventsMapFromProjection projection
+      .then (eventsMap) =>
+        @_applyDomainEventsFromStoreToProjection projectionId, projection, eventsMap, aggregateId
       .then (eventNames) =>
         @log.debug "[#{@_context.name}] Finished Replaying DomainEvents against Projection #{projectionName}"
         @_subscribeProjectionToDomainEvents projectionId, projectionName, projection, eventNames, aggregateId, domainEventStreamName
@@ -126,42 +125,112 @@ class Projection
         resolve()
 
 
-  _parseEventNamesFromProjection: (projection) ->
+  _parseEventsMapFromProjection: (projection) ->
     new Promise (resolve, reject) =>
-      eventNames = []
+      eventsMap = {}
+      
       for key, value of projection
         if (key.indexOf 'handle') is 0 and (typeof value is 'function')
           eventName = key.replace /^handle/, ''
-          eventNames.push eventName
-      resolve eventNames
+          eventsMap[@_context.name] ?= []
+          eventsMap[@_context.name].push eventName
+        else if (key.indexOf 'from') is 0 and (typeof value is 'function')
+          contextName = key.replace /^from/, ''
+          contextName = contextName.replace /_.*$/, ''
+          eventsMap[contextName] ?= []
+          eventName = key.replace /.*_handle/, ''
+          eventsMap[contextName].push eventName
+          
+      resolve eventsMap
 
+  _generateSubProjectionStoredDomainEventsHandler: (ready) ->
+    return (domainEvents) =>
+      new Promise (resolve, reject) =>
+        ready
+          domainEvents: domainEvents
+          promise:
+            resolve: resolve
+            reject: reject
 
-  _applyDomainEventsFromStoreToProjection: (projectionId, projection, eventNames, aggregateId) ->
+      
+  _createSubProjection: (projectionId, projection, contextName, eventNames) ->
     new Promise (resolve, reject) =>
-      @_domainEventsApplied[projectionId] = {}
+      remote = false
+      subContext = @_eventric.getContext contextName
+      if not subContext
+        subContext = @_eventric.remote contextName
+        remote = true
+      
+      if not subContext
+        err = new Error("Context #{contextName} not found")
+        @log.error err
+        return reject err
+        
+      subProjection = {
+        $handleStoredDomainEvents: @_generateSubProjectionStoredDomainEventsHandler resolve
+      }
+      
+      for eventName in eventNames
+        subProjection["handle#{eventName}"] = projection["from#{contextName}_handle#{eventName}"].bind(projection)
+        
+      subProjectionName = "_globalProjection_#{projectionId}"
+      subContext.addProjection subProjectionName, subProjection
+      if subContext._initialized or remote then subContext.initializeProjectionInstance subProjectionName
+      
+      projection.$subProjections ?= {}
+      projection.$subProjections[contextName] = subProjection
 
+
+  _applyDomainEventsFromStoreToProjection: (projectionId, projection, eventsMap, aggregateId) ->
+    @_domainEventsApplied[projectionId] = {}
+    promises = []
+    for contextName, eventNames of eventsMap when contextName isnt @_context.name
+      promises.push @_createSubProjection(projectionId, projection, contextName, eventNames)
+      
+    if eventsMap[@_context.name]
       if aggregateId
-        findEvents = @_context.findDomainEventsByNameAndAggregateId eventNames, aggregateId
+        promises.push @_context.findDomainEventsByNameAndAggregateId eventsMap[@_context.name], aggregateId
       else
-        findEvents = @_context.findDomainEventsByName eventNames
-
-      findEvents
-      .then (domainEvents) =>
-        if not domainEvents or domainEvents.length is 0
-          return resolve eventNames
-
-        @_eventric.eachSeries domainEvents, (domainEvent, next) =>
-          @_applyDomainEventToProjection domainEvent, projection
-          .then =>
-            @_domainEventsApplied[projectionId][domainEvent.id] = true
-            next()
-
-        , (err) ->
-          return reject err if err
-          resolve eventNames
-
-      .catch (err) ->
-        reject err
+        promises.push @_context.findDomainEventsByName eventsMap[@_context.name]
+      
+    Promise.all promises
+    .then (initials) =>
+      new Promise (resolve, reject) =>
+        domainEvents = []
+        for key, value of initials
+          if typeof value.domainEvents isnt 'undefined'
+            domainEvents = domainEvents.concat value.domainEvents
+          else 
+            domainEvents = domainEvents.concat value
+        
+        resolvePromise = =>
+          value.promise.resolve(eventsMap) for key, value of initials when typeof value.promise isnt 'undefined'
+          resolve eventsMap[@_context.name]
+          
+        rejectPromise = (err) =>
+          value.promise.reject(err) for key, value of initials when typeof value.promise isnt 'undefined'
+          resolve err
+          
+        domainEvents.sort (a, b) ->
+          if a.timestamp > b.timestamp then return 1 
+          if a.timestamp < b.timestamp then return -1
+          return 0
+        
+        if typeof projection.$handleStoredDomainEvents is 'function'
+          projection.$handleStoredDomainEvents(domainEvents)
+          .then resolvePromise
+          .catch rejectPromise
+        else
+          @_eventric.eachSeries domainEvents, (domainEvent, next) =>
+            @_applyDomainEventToProjection domainEvent, projection
+            .then =>
+              @_domainEventsApplied[projectionId][domainEvent.id] = true
+              next()
+    
+          , (err) ->
+            return rejectPromise(err) if err
+            resolvePromise()
+  
 
 
   _subscribeProjectionToDomainEvents: (projectionId, projectionName, projection, eventNames, aggregateId, domainEventStreamName) ->
@@ -211,20 +280,26 @@ class Projection
           resolve()
 
 
-  _applyDomainEventToProjection: (domainEvent, projection) =>  new Promise (resolve, reject) =>
-    if !projection["handle#{domainEvent.name}"]
+  _applyDomainEventToProjection: (domainEvent, projection) => new Promise (resolve, reject) =>
+    if projection["handle#{domainEvent.name}"] and projection["from#{domainEvent.context}_handle#{domainEvent.name}"]
+      err = new Error("handle#{domainEvent.name} is ambiguous !")
+      @log.error err
+      return reject err
+      
+    handlerFn = projection["handle#{domainEvent.name}"] || projection["from#{domainEvent.context}_handle#{domainEvent.name}"]
+    if !handlerFn
       @log.debug "Tried to apply DomainEvent '#{domainEvent.name}' to Projection without a matching handle method"
       return resolve()
 
-    if projection["handle#{domainEvent.name}"].length == 2
+    if handlerFn.length == 2
       # promise defined inside the handler
-      projection["handle#{domainEvent.name}"] domainEvent,
+      handlerFn.call projection, domainEvent,
         resolve: resolve
         reject: reject
 
     else
       # no promise defined inside the handler
-      projection["handle#{domainEvent.name}"] domainEvent
+      handlerFn.call projection, domainEvent
       resolve()
 
 

--- a/src/projection/projection_feature.spec.coffee
+++ b/src/projection/projection_feature.spec.coffee
@@ -56,3 +56,89 @@ describe 'Projection Feature', ->
           exampleContext.getProjectionStore 'inmemory', 'ExampleProjection'
           .then (projectionStore) ->
             expect(projectionStore).to.deep.equal totallyDenormalized: 'foo'
+
+describe 'Global Projection Feature', ->
+
+  describe 'given we created and initialized some example contexts then create a Global Projection', ->
+    exampleContext1 = null
+    exampleContext2 = null
+    
+    createBasicContext = (name) ->
+      exampleContext = eventric.context name
+
+      exampleContext.defineDomainEvents
+        ExampleCreated: ->
+
+        SomethingHappened: (params) ->
+          @specific = params.whateverFoo
+
+      exampleContext.addAggregate 'Example', ->
+        create: ->
+          @$emitDomainEvent 'ExampleCreated'
+        doSomething: ->
+          @$emitDomainEvent 'SomethingHappened', whateverFoo: 'foo'
+
+      exampleContext.addCommandHandlers
+        CreateExample: () ->
+          @$aggregate.create 'Example'
+          .then (example) ->
+            example.$save()
+
+        doSomethingWithExample: (params) ->
+          @$aggregate.load 'Example', params.id
+          .then (example) ->
+            example.doSomething()
+            example.$save()
+
+      exampleContext.enableWaitingMode()
+        
+      exampleContext
+      
+    addProjection = ->
+      exampleContext1.addProjection 'ExampleProjection', ->
+        stores: ['inmemory']
+
+        fromContext1_handleSomethingHappened: (domainEvent) ->
+          @$store.inmemory.totallyDenormalizedc1 = domainEvent.payload.specific
+          
+        fromContext2_handleSomethingHappened: (domainEvent) ->
+          @$store.inmemory.totallyDenormalizedc2 = domainEvent.payload.specific
+          
+      exampleContext1.initializeProjectionInstance 'ExampleProjection'
+      
+    beforeEach ->
+      #eventric.log.setLogLevel('debug');
+      exampleContext1 = createBasicContext 'Context1'
+      exampleContext2 = createBasicContext 'Context2'
+      
+      Promise.all([
+        exampleContext1.initialize()
+        exampleContext2.initialize()
+      ])
+      
+    
+    
+    describe 'when DomainEvents got emitted which the Projection subscribed to', ->
+      it 'then the Projection should call the projectionStore with the denormalized state', ->
+        addProjection()
+        .then ->
+          exampleContext2.command 'CreateExample'
+        .then (exampleId) ->
+          exampleContext2.command 'doSomethingWithExample', id: exampleId
+        .then ->
+          exampleContext1.getProjectionStore 'inmemory', 'ExampleProjection'
+          .then (projectionStore) ->
+            expect(projectionStore).to.deep.equal totallyDenormalizedc2: 'foo'
+            
+    describe 'when DomainEvents exists in stores before projection initialize', ->
+      it 'then the projectionStore should be with the denormalized state', ->
+        
+        exampleContext2.command 'CreateExample'
+        .then (exampleId) ->
+          exampleContext2.command 'doSomethingWithExample', id: exampleId
+        .then ->
+          addProjection()
+        .then ->
+          exampleContext1.getProjectionStore 'inmemory', 'ExampleProjection'
+          .then (projectionStore) ->
+            expect(projectionStore).to.deep.equal totallyDenormalizedc2: 'foo'

--- a/src/remote/remote.coffee
+++ b/src/remote/remote.coffee
@@ -16,6 +16,7 @@ class Remote
     @_clients = {}
     @_projectionClasses = {}
     @_projectionInstances = {}
+    @_projectionInitializable = true
     @_handlerFunctions = {}
     @projectionService = new @_eventric.Projection @_eventric
     @addClient 'inmemory', @InMemoryRemote.client


### PR DESCRIPTION
Here is working global projections :

- integrated to projection service
- playing past events sorted
- should work with remotes (test undone)

#### todos

- ~~Handle bind() breaking client tests... because encapsulation in a handler generator will duplicate the arguments counting to handle promise. Think about [Pollyfill](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Function/bind#Compatibility)~~
- remote context tests
- Handle an array of remote contexts to avoid remotes duplication
- destroy subProjections

#### Main flow

Most are in `_applyDomainEventsFromStoreToProjection`, it creates an array of promises waiting for each context domain events with a special `$handleStoredDomainEvents` method in subProjections (it works with normal projections too... It waits just a promise to deal all past domain events)

It adds local context domainEvents to promises array

Main projection sort and play all events then solves all `$handleStoredDomainEvents` promises