### PR TITLE
context: Fix initialization of multiple projections

### DIFF
--- a/src/context/context.coffee
+++ b/src/context/context.coffee
@@ -106,11 +106,7 @@ class Context
 
 
   _initializeProjections: ->
-    initializeProjectionsPromise = Promise.resolve()
-    for projectionObject in @_projectionObjects
-      initializeProjectionsPromise = initializeProjectionsPromise.then =>
-        @_projectionService.initializeInstance projectionObject, {}
-    return initializeProjectionsPromise
+    Promise.all (@_projectionService.initializeInstance projectionObject, {} for projectionObject in @_projectionObjects)
 
 
   getDomainEventPayloadConstructor: (domainEventName) ->

--- a/src/context/context.feature_spec.coffee
+++ b/src/context/context.feature_spec.coffee
@@ -56,6 +56,16 @@ describe 'Context Feature', ->
       .then ->
         expect(projectionObject.initialize).to.have.been.called
 
+    it 'should correctly call initialize method of multiple projections', ->
+      exampleContext = eventric.context 'exampleContext'
+
+      projections = (initialize: sandbox.stub().yields() for i in [1..3])
+      for projection in projections
+        exampleContext.addProjection projection
+      exampleContext.initialize()
+      .then ->
+        for projection in projections
+          expect(projection.initialize).to.have.been.called
 
 
   describe 'destroying a context', ->


### PR DESCRIPTION
Hoisting of projectionObject variable in _initializeProjections method caused
that the compound promise initialized only the last projectionObject (and that
n-times to make things worse).

This caused situation where there were no events being received by all but
the last projection and many duplicate events received by the last one.